### PR TITLE
MH-21 Global Request Organization Part 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,4 +66,5 @@ gem 'annotate', group: :development
 gem 'jquery-rails'
 
 
-
+gem 'has_scope'
+gem 'simple_form'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,9 @@ GEM
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    has_scope (0.7.2)
+      actionpack (>= 4.1)
+      activesupport (>= 4.1)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.0)
@@ -180,6 +183,9 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    simple_form (5.0.3)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -230,6 +236,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   devise
+  has_scope
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   jquery-rails
@@ -240,6 +247,7 @@ DEPENDENCIES
   rails (~> 6.0.3, >= 6.0.3.3)
   sass-rails (>= 6)
   selenium-webdriver
+  simple_form
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/assets/stylesheets/globals.scss
+++ b/app/assets/stylesheets/globals.scss
@@ -1,3 +1,4 @@
 // Place all the styles related to the Globals controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+

--- a/app/controllers/globals_controller.rb
+++ b/app/controllers/globals_controller.rb
@@ -1,14 +1,17 @@
     class GlobalsController < ApplicationController
-        before_action :authenticate_user!
-      
+
          def index
               @users = User.all
-              globals = Global.all
+              @globals = Global.all
+              @globals = Global.filter(params[:sender])
+              
               respond_to do |format|
-                  format.html { render :index, locals: { globals: globals } }
+                  format.html { render :index, locals: { globals: @globals } }
               end
           end
-     
+          
+          
+
          def show
              
              global = Global.find(params[:id])

--- a/app/models/global.rb
+++ b/app/models/global.rb
@@ -17,5 +17,19 @@
 #  user_id             :bigint
 #
 class Global < ApplicationRecord
-  
+ 
+    def self.filter(filter)
+        if filter and not filter.empty?
+            @globals = Global.all
+            @globals= @globals.where(sender: filter)
+            
+
+            #byebug
+            return @globals
+        else
+            Global.all
+        end 
+    end
+ 
+
 end

--- a/app/views/globals/index.html.erb
+++ b/app/views/globals/index.html.erb
@@ -1,5 +1,6 @@
 
 <!DOCTYPE html>
+
 <style>
 body {
   margin: 0;
@@ -23,7 +24,11 @@ body {
   transform: translate(-50%, -50%);
   color: white;
 }
+
+
+
 </style>
+
 <br>
 <div class="big_header">
             <h1 class="blue" style="color:#2196F3;">Global Request Forum </h1>  
@@ -44,10 +49,19 @@ body {
 </div>
 </div>
   </div>
+  
 </div>    
 <br>
 
-<% globals.each do |global| %>
+
+<h4>Filter by:</h4>
+    <%= form_tag(globals_path, method: "get") do %>
+        <%= select_tag "sender", options_from_collection_for_select(Global.all.to_a.uniq{ |o| o.sender}, :sender, :sender), prompt: 'Sender'%>
+        <input type="submit" value="Submit">
+    <% end %> <!-- end of form -->
+
+
+<% @globals.each do |global| %>
 
   
   <div id="<%= dom_id(global) %>">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,9 +42,17 @@
           <%= link_to "Global Requests", globals_path, class: 'nav-link' %>
             
           </li>
-            <li class="nav-item">
-              <%= link_to 'My Requests', requests_path, class: 'nav-link' %>
+          <% if user_signed_in? %>
+            <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"> My Requests</a>
+              <div class="dropdown-menu dropdown-menu-left" aria-labelledby="navbarDropdown">
+                <%= link_to 'My Direct Requests ', requests_path, class: "dropdown-item"%>
+                  <%= link_to "My Global Requests", home_path, class:"dropdown-item" %>
+              </div>
             </li>
+          <% end %>
+
+
             <li class="nav-item">
           <%= link_to "My Reviews", reviews_path, class: 'nav-link' %>
             

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+#
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/heartcombo/simple_form#custom-components to know
+# more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+#
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Wrappers are used by the form builder to generate a
+  # complete input. You can remove any component from the
+  # wrapper, change the order or even add your own to the
+  # stack. The options given below are used to wrap the
+  # whole input.
+  config.wrappers :default, class: :input,
+    hint_class: :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
+    ## Extensions enabled by default
+    # Any of these extensions can be disabled for a
+    # given input by passing: `f.input EXTENSION_NAME => false`.
+    # You can make any of these extensions optional by
+    # renaming `b.use` to `b.optional`.
+
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
+    b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.optional :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    ## Inputs
+    # b.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label_input
+    b.use :hint,  wrap_with: { tag: :span, class: :hint }
+    b.use :error, wrap_with: { tag: :span, class: :error }
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :nested
+
+  # Default class for buttons
+  config.button_class = 'btn'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  # config.collection_wrapper_tag = nil
+
+  # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = nil
+
+  # You can wrap each item in a collection of radio/check boxes with a tag,
+  # defaulting to :span.
+  # config.item_wrapper_tag = :span
+
+  # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = nil
+
+  # How the label text should be generated altogether with the required text.
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+
+  # You can define the class to use on all labels. Default is nil.
+  # config.label_class = nil
+
+  # You can define the default class to be used on forms. Can be overriden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  # config.wrapper_mappings = { string: :prepend }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  # config.custom_inputs_namespaces << "CustomInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+
+  # Defines validation classes to the input_field. By default it's nil.
+  # config.input_field_valid_class = 'is-valid'
+  # config.input_field_error_class = 'is-invalid'
+end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,11 @@ Rails.application.routes.draw do
 
 
 # globals
+#get 'globals/myglobals', to: 'my_globals#myglobals', as: 'my_globals'
+#resources :globals, only: [:index, :show]
 get 'globals', to: 'globals#index', as: 'globals' # index
+
+
 get 'globals/new', to: 'globals#new', as: 'new_global' # new
 post 'globals', to: 'globals#create' # create
 get 'globals/:id', to: 'globals#show', as: 'global' # show

--- a/lib/templates/erb/scaffold/_form.html.erb
+++ b/lib/templates/erb/scaffold/_form.html.erb
@@ -1,0 +1,15 @@
+<%# frozen_string_literal: true %>
+<%%= simple_form_for(@<%= singular_table_name %>) do |f| %>
+  <%%= f.error_notification %>
+  <%%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
+
+  <div class="form-inputs">
+  <%- attributes.each do |attribute| -%>
+    <%%= f.<%= attribute.reference? ? :association : :input %> :<%= attribute.name %> %>
+  <%- end -%>
+  </div>
+
+  <div class="form-actions">
+    <%%= f.button :submit %>
+  </div>
+<%% end %>


### PR DESCRIPTION
Task Description:
After much gnashing of teeth I gave up on trying to implement a secondary index view for global requests, namely a personal view where users could see only their global requests. Instead I have opted to implement a filter function on global request page. At present the filter will filter by sender name. The drop down should populate based on current posted global requests.

I will continue to try to find a way to either implement personal index page or add additional features to filter.

How to Evaluate:
Run the app. Sign in as alice@email.com with "password"

You should be able to go to global request tab in nav bar and post a global request.  If you post a few other global requests for different users the names of all users who posted the requests should appear in the filter drop down box. You can filter that way by sender name.